### PR TITLE
Raylib now requires minimum cmake 3.25, update cmakelists to reflect …

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.25)
 project(Boids CXX C)
 
 set(CMAKE_CXX_STANDARD 20)


### PR DESCRIPTION
…that